### PR TITLE
DM-11921: Change match method in DIAObjectCollection to return DIAObject ids

### DIFF
--- a/python/lsst/ap/association/assoc_db_sqlite.py
+++ b/python/lsst/ap/association/assoc_db_sqlite.py
@@ -20,7 +20,7 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
-""" Simple sqlite3 interface for storing and retriving DIAObjects and
+""" Simple sqlite3 interface for storing and retrieving DIAObjects and
 DIASources. This class is mainly for testing purposes in the context of
 ap_pipe/ap_verify.
 """
@@ -47,7 +47,7 @@ __all__ = ["AssociationDBSqliteConfig",
 
 class SqliteDBConverter(object):
     """ Class for defining conversions to and from an sqlite database and
-    afw SourceRecord bjects.
+    afw SourceRecord objects.
 
     Attributes
     ----------
@@ -112,7 +112,7 @@ class SqliteDBConverter(object):
         Parameters
         ----------
         db_row : list of values
-            Database values retived to write into the sr_record
+            Retrieved values from the database to convert into a SourceRecord.
 
         Return
         ------
@@ -177,7 +177,7 @@ class AssociationDBSqliteTask(pipeBase.Task):
     Create a simple sqlite database and implement wrappers to store and
     retrieve DIAObjects and DIASources from within that database. This task
     functions as a testing ground for the L1 database and should mimic this
-    database's eventual functionaly. This specific database implementation is
+    database's eventual functionality. This specific database implementation is
     useful for the verification packages which may not be run with access to
     L1 database.
 
@@ -258,7 +258,7 @@ class AssociationDBSqliteTask(pipeBase.Task):
     @pipeBase.timeMethod
     def load(self, ctr_coord, radius):
         """ Load all DIAObjects and associated DIASources within
-        the specified cirlce.
+        the specified circle.
 
         This method is approximate to the input circle as it will
         return the DIAObjects that are contained within the pixels
@@ -269,7 +269,7 @@ class AssociationDBSqliteTask(pipeBase.Task):
         ctr_coord : lsst.afw.geom.SpherePoint
             Center position of the circle on the sky to load.
         radius : lsst.afw.geom.Angle
-            Distance from ctr_coord defining a cirlce on the sky
+            Distance from ctr_coord defining a circle on the sky
             within which to load DIAObjects and associated DIASources.
 
         Returns
@@ -321,7 +321,7 @@ class AssociationDBSqliteTask(pipeBase.Task):
 
     @pipeBase.timeMethod
     def store_updated(self, dia_collection,
-                      updated_dia_collection_indices):
+                      updated_dia_collection_ids):
         """ Store new DIAObjects and sources in the sqlite database.
 
         This method is intended to be used on a per-visit basis with the
@@ -334,15 +334,12 @@ class AssociationDBSqliteTask(pipeBase.Task):
             A collection of DIAObjects that contains newly created or updated
             DIAObjects. Only the new or updated DIAObjects are stored.
         updated_dia_collection_indices : int ndarray
-            Indices within the set DIAObjectCollection that should be stored
-            as updated DIAObjects in the database.
-
-        TODO:
-            Change updated_dia_collection_indices to updated_dia_object_ids.
-            DM-11921
+            Ids of DIAObjects within the set DIAObjectCollection that should
+            be stored as updated DIAObjects in the database.
         """
-        for updated_collection_index in updated_dia_collection_indices:
-            dia_object = dia_collection.dia_objects[updated_collection_index]
+        for updated_collection_id in updated_dia_collection_ids:
+            dia_object = dia_collection.get_dia_object(
+                updated_collection_id)
             dia_object.dia_object_record.set(
                 'indexer_id',
                 self.indexer.index_points([dia_object.ra.asDegrees()],
@@ -359,14 +356,12 @@ class AssociationDBSqliteTask(pipeBase.Task):
         self._commit()
 
     def _get_dia_objects(self, indexer_indices):
-        """ Retrive the DIAObjects from the database whose indexer indices
+        """ Retrieve the DIAObjects from the database whose indexer indices
         are with the specified list of indices.
 
-        Retrives a list of DIAObjects that are covered by the pixels with
-        indices, indexer_indices. Use this to retrive the complete DIAObject
-        including the associated sources. Using this method instead of `load`
-        will avoid the overhead of creating a DIAObjectCollection if that is
-        desired.
+        Retrieves a list of DIAObjects that are covered by the pixels with
+        indices, indexer_indices. Use this to retrieve the complete DIAObject
+        including the associated sources.
 
         Parameters
         ----------
@@ -425,11 +420,11 @@ class AssociationDBSqliteTask(pipeBase.Task):
         return output_rows
 
     def _get_dia_object_records(self, indexer_indices):
-        """ Retrive the SourceCatalog of objects representing the DIAObjects
+        """ Retrieve the SourceCatalog of objects representing the DIAObjects
         in the spatial indices specified.
 
-        Retrives the SourceRecords that are covered by the pixels with
-        indices, indexer_indices. Use this to retrive the summary statistics
+        Retrieves the SourceRecords that are covered by the pixels with
+        indices, indexer_indices. Use this to retrieve the summary statistics
         of the DIAObjects themselves rather than taking the extra overhead
         of loading the associated DIASources as well.
 
@@ -453,12 +448,12 @@ class AssociationDBSqliteTask(pipeBase.Task):
         return output_dia_objects
 
     def _get_dia_sources(self, dia_obj_id):
-        """ Retrive all DIASources associated with this DIAObject id.
+        """ Retrieve all DIASources associated with this DIAObject id.
 
         Parameters
         ----------
         dia_obj_id : int
-            Id of the DIAObject that is asssociated with the DIASources
+            Id of the DIAObject that is associated with the DIASources
             of interest.
 
         Returns
@@ -504,7 +499,7 @@ class AssociationDBSqliteTask(pipeBase.Task):
         Parameters
         ----------
         source_record : lsst.afw.table.SourcRecord
-            SourceRecord to store in the database table spcified by
+            SourceRecord to store in the database table specified by
             converter.
         converter : lsst.ap.association.SqliteDBConverter
             A converter object specifying the correct database table to write

--- a/python/lsst/ap/association/association.py
+++ b/python/lsst/ap/association/association.py
@@ -53,15 +53,15 @@ class AssociationTask(pipeBase.Task):
     """!
     Associate DIAOSources into existing DIAObjects.
 
-    This task performs the assocation of detected DIASources in a visit
+    This task performs the association of detected DIASources in a visit
     with the previous DIAObjects detected over time. It also creates new
     DIAObjects out of DIASources that cannot be associated with previously
     detected DIAObjects.
 
     Attributes
     ----------
-    level1_db : lsst.ap.assoiation.AssoiationDBSqlite
-        A wrapper class for handling persitence of DIAObjects and DIASources.
+    level1_db : lsst.ap.association.AssoiationDBSqlite
+        A wrapper class for handling persistence of DIAObjects and DIASources.
     """
 
     ConfigClass = AssociationConfig
@@ -100,9 +100,9 @@ class AssociationTask(pipeBase.Task):
                                                     dia_sources)
 
         dia_collection = association_result.dia_collection
-        updated_obj_indices = association_result.updated_indices
+        updated_obj_ids = association_result.updated_ids
 
-        self.level1_db.store_updated(dia_collection, updated_obj_indices)
+        self.level1_db.store_updated(dia_collection, updated_obj_ids)
 
     @pipeBase.timeMethod
     def associate_sources(self, dia_collection, dia_sources):
@@ -111,7 +111,7 @@ class AssociationTask(pipeBase.Task):
         Parameters
         ----------
         dia_collection : lsst.ap.association.DIAObjectCollection
-            Collection of DIAObjects to atempt to associate the input
+            Collection of DIAObjects to attempt to associate the input
             DIASources into.
         dia_sources : lsst.afw.table.SourceCatalog
             DIASources to associate into the DIAObjectCollection.
@@ -122,5 +122,5 @@ class AssociationTask(pipeBase.Task):
 
         return pipeBase.Struct(
             dia_collection=dia_collection,
-            updated_indices=updated_dia_objects
+            updated_ids=updated_dia_objects
         )

--- a/python/lsst/ap/association/dia_object.py
+++ b/python/lsst/ap/association/dia_object.py
@@ -49,7 +49,7 @@ def make_minimal_dia_object_schema():
     # as well as their errors.
 
     # In the future we would like to store a covariance of the coordinate.
-    # This functionality is not defined in currenting in the stack, so we will
+    # This functionality is not defined in currently in the stack, so we will
     # hold off until it is implemented. This is to be addressed in DM-7101.
     schema.addField("indexer_id", type=np.int64)
 
@@ -125,13 +125,13 @@ class DIAObject(object):
         A SourceRecord column value
         """
 
-        # This will in the future be replaced with a overwritting of __getattr
+        # This will in the future be replaced with a overwriting of __getattr
         # and __dir__ for this class.
         return self._dia_object_record.get(name)
 
     def update(self):
         """ Compute all summary statistics given the current catalog of
-        DIASources asigned to this DIAObject.
+        DIASources assigned to this DIAObject.
 
         Store these summaries (e.g. median RA/DEC position, fluxes...) in
         the object_source_record attribute and set the class variable
@@ -141,7 +141,7 @@ class DIAObject(object):
         self._updated = False
 
         # To quickly compute the summary statistics we check if the catalog
-        # is currently contious and if not we make a deep copy.
+        # is currently continuous and if not we make a deep copy.
         if not self._dia_source_catalog.isContiguous():
             tmp_dia_source_catalog = self._dia_source_catalog.copy(deep=True)
             self._dia_source_catalog = tmp_dia_source_catalog
@@ -208,7 +208,7 @@ class DIAObject(object):
         # dia_source_catalog.
 
         raise NotImplementedError(
-            "Light curves not yet implimented. Use dia_source_catalog property"
+            "Light curves not yet implemented. Use dia_source_catalog property"
             "instead.")
 
     @property
@@ -227,7 +227,7 @@ class DIAObject(object):
 
     @property
     def dia_object_record(self):
-        """ Retrive the SourceRecord that represents the summary statistics on
+        """ Retrieve the SourceRecord that represents the summary statistics on
         this DIAObject's set of DIASources.
 
         Return
@@ -238,7 +238,7 @@ class DIAObject(object):
 
     @property
     def dia_source_catalog(self):
-        """ Retrive the SourceCatalog that represents the DIASources that make
+        """ Retrieve the SourceCatalog that represents the DIASources that make
         up this DIAObject.
 
         Return

--- a/tests/test_association_db_sqlite.py
+++ b/tests/test_association_db_sqlite.py
@@ -95,7 +95,8 @@ class TestAssociationDBSqlite(unittest.TestCase):
     def _compare_source_records(self, record_a, record_b):
         """ Compare the values stored in two source records.
 
-        This comparisons assumes the two schema are identical.
+        This comparison assumes that the schema for record_a is a
+        subset of or equal to the schema of record_b.
 
         Parameters
         ----------
@@ -126,7 +127,7 @@ class TestAssociationDBSqlite(unittest.TestCase):
         self._test_store_index_option(False)
 
     def _test_store_index_option(self, update_spatial_index):
-        """ Convience function for testing the store method.
+        """ Convenience function for testing the store method.
 
         Parameters
         ---------
@@ -140,7 +141,7 @@ class TestAssociationDBSqlite(unittest.TestCase):
             start_angle_degrees=0.1,
             scatter_arcsec=0.0)
         if not update_spatial_index:
-            # Set the spatial index to some arbitray value
+            # Set the spatial index to some arbitrary value
             dia_objects[0].dia_object_record.set('indexer_id', 10)
         dia_collection = DIAObjectCollection(dia_objects)
 
@@ -150,7 +151,7 @@ class TestAssociationDBSqlite(unittest.TestCase):
             "SELECT * FROM dia_objects")
         for row in self.assoc_db._db_cursor.fetchall():
             if update_spatial_index:
-                # Index is HTM cell number at level=7, RA,DEC=0.1
+                # Value is HTM cell number at level=7, RA,DEC=0.1
                 dia_objects[0].dia_object_record.set('indexer_id', 253952)
             round_trip_object = \
                 self.assoc_db._dia_object_converter.source_record_from_db_row(
@@ -301,7 +302,7 @@ class TestAssociationDBSqlite(unittest.TestCase):
             self._compare_source_records(dia_source, created_source)
 
     def test_store_dia_object_dia_source_pair(self):
-        """ Test storing the ids of assocated DIAObjects and DIASources.
+        """ Test storing the ids of associated DIAObjects and DIASources.
         """
         for obj_id in range(2):
             for src_id in range(5):
@@ -338,8 +339,7 @@ class TestAssociationDBSqlite(unittest.TestCase):
     def _store_and_retrieve_source_record(self,
                                           source_record,
                                           converter):
-        """ Convenience method for round tripping a soruce
-        record object.
+        """ Convenience method for round tripping a source record object.
 
         Parameters
         ----------

--- a/tests/test_dia_collection.py
+++ b/tests/test_dia_collection.py
@@ -51,7 +51,7 @@ def create_test_dia_objects(n_objects=5, n_sources=5, start_id=0,
         of the first object will be RA=start_angle_degrees,
         DEC=start_angle_degreesi
     increment_degrees : float
-        Ammount to increment RA and DEC by for each new DIAObject
+        Amount to increment RA and DEC by for each new DIAObject
     scatter_arcsec : float
         Scatter to add to the position of each DIASource.
 
@@ -184,15 +184,14 @@ class TestDIAObjectCollection(unittest.TestCase):
         # except the last DIAObject in this collection which should be
         # newly created during the matching step and contain only one
         # DIASource.
-        updated_indices = obj_collection.match(src_cat, score_struct)
+        updated_ids = obj_collection.match(src_cat, score_struct)
         self.assertEqual(len(obj_collection.dia_objects), 5)
 
-        for idx, obj_id in enumerate(obj_collection.get_dia_object_ids()):
-            self.assertEqual(idx, updated_indices[idx])
-            # We created a new DIAObject in the collection hence the last
-            # DIAObject in this collection is new and contains only one
-            # DIASource.
-            if idx == len(obj_collection.dia_objects) - 1:
+        for updated_idx, obj_id in enumerate(updated_ids):
+            if updated_idx == len(updated_ids) - 1:
+                # We created a new DIAObject in the collection hence the last
+                # DIAObject in this collection is new and contains only one
+                # DIASource.
                 self.assertEqual(
                     obj_collection.get_dia_object(obj_id).n_dia_sources, 1)
             else:
@@ -207,7 +206,7 @@ class TestDIAObjectCollection(unittest.TestCase):
         for src_idx, src in enumerate(src_cat):
             edit_and_offset_source_record(
                 src,
-                src_idx + 4,
+                src_idx,
                 0.1 * src_idx,
                 0.1 * src_idx,
                 -1)
@@ -224,7 +223,7 @@ class TestDIAObjectCollection(unittest.TestCase):
         self.assertEqual(len(dia_collection.dia_objects), 5)
 
         for idx, obj_id in enumerate(dia_collection.get_dia_object_ids()):
-            self.assertEqual(idx, updated_indices[idx])
+            self.assertEqual(obj_id, updated_indices[idx])
             # We created a new DIAObject in the collection hence the last
             # DIAObject in this collection is new and contains only one
             # DIASource.

--- a/tests/test_dia_object.py
+++ b/tests/test_dia_object.py
@@ -60,7 +60,7 @@ class TestDIAObject(unittest.TestCase):
 
     def test_init(self):
         """ Test DIAObject creation and if we can properly instantiate a
-        DIAObject from an already create dia_object_record.
+        DIAObject from an already created dia_object_record.
         """
         single_source = create_test_dia_sources(1)
 
@@ -102,7 +102,7 @@ class TestDIAObject(unittest.TestCase):
 
     def test_update(self):
         """ If we instantiate the class with a set of DIASources we test to
-        make sure that the DIAObject is intantiated correctly and that we
+        make sure that the DIAObject is instantiated correctly and that we
         compute the summary statistics in the expected way.
         """
         sources = create_test_dia_sources(5)


### PR DESCRIPTION
Previous the code returned the index in the the list of DIAObjects
in the DIACollection.

Fixed bugs in unittests.